### PR TITLE
Decimal Degrees to MGRS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV WORK=/opt/mgrs
 # set geotrans environment variables
 ENV LD_LIBRARY_PATH=/opt/mgrs/geotrans3.7/CCS/linux_64
 ENV MSPCCS_DATA=/opt/mgrs/geotrans3.7/data
+ENV MSPCCS_USE_LEGACY_GEOTRANS=true
 
 # set workdir
 WORKDIR ${WORK}

--- a/geotrans3.7/CCS/sampleCode/mgrsToGeodetic.cpp
+++ b/geotrans3.7/CCS/sampleCode/mgrsToGeodetic.cpp
@@ -1,3 +1,4 @@
+
 #include <napi.h>
 #include <ctime>
 #include <cerrno>
@@ -26,30 +27,115 @@ using namespace Napi;
  * convert the given x, y, z coordinates to a lat, lon, and height.
  **/
 void convertGeocentricToGeodeticMslEgm96(
-    MSP::CCS::CoordinateConversionService& ccsGeocentricToGeodeticMslEgm96,
-    double x,
-    double y,
-    double z,
-    double& lat,
-    double& lon,
-    double& height)
-{
+  MSP::CCS::CoordinateConversionService & ccsGeocentricToGeodeticMslEgm96,
+  double x,
+  double y,
+  double z,
+  double & lat,
+  double & lon,
+  double & height) {
+  MSP::CCS::Accuracy sourceAccuracy;
+  MSP::CCS::Accuracy targetAccuracy;
+  MSP::CCS::CartesianCoordinates sourceCoordinates(
+    MSP::CCS::CoordinateType::geocentric, x, y, z);
+  MSP::CCS::GeodeticCoordinates targetCoordinates(
+    MSP::CCS::CoordinateType::geodetic, lon, lat, height);
+
+  ccsGeocentricToGeodeticMslEgm96.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
+    targetCoordinates,
+    targetAccuracy);
+
+  lat = targetCoordinates.latitude();
+  lon = targetCoordinates.longitude();
+  height = targetCoordinates.height();
+}
+
+/**
+ * Function which uses the given Geodetic (MSL EGM 96 15M) to Geodetic
+ * (Ellipsoid Height) Coordinate Conversion Service,
+ * 'ccsMslEgm96ToEllipsoidHeight', to convert the given MSL height at the
+ * given lat, lon, to an Ellipsoid height.
+ **/
+void convertMslEgm96ToEllipsoidHeight(
+  MSP::CCS::CoordinateConversionService & ccsMslEgm96ToEllipsoidHeight,
+  double lat,
+  double lon,
+  double mslHeight,
+  double & ellipsoidHeight) {
+  MSP::CCS::Accuracy sourceAccuracy;
+  MSP::CCS::Accuracy targetAccuracy;
+  MSP::CCS::GeodeticCoordinates sourceCoordinates(
+    MSP::CCS::CoordinateType::geodetic, lon, lat, mslHeight);
+  MSP::CCS::GeodeticCoordinates targetCoordinates;
+
+  ccsMslEgm96ToEllipsoidHeight.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
+    targetCoordinates,
+    targetAccuracy);
+
+  ellipsoidHeight = targetCoordinates.height();
+}
+
+/**
+ * Function which uses the given Geodetic (Ellipsoid Height) to Geocentric 
+ * Coordinate Conversion Service, 'ccsGeodeticEllipsoidToGeocentric', to
+ * convert the given lat, lon, and height to x, y, z coordinates.
+ **/
+void convertGeodeticEllipsoidToGeocentric(
+    MSP::CCS::CoordinateConversionService & ccsGeodeticEllipsoidToGeocentric,
+    double lat,
+    double lon,
+    double height,
+    double & x,
+    double & y,
+    double & z) {
     MSP::CCS::Accuracy sourceAccuracy;
     MSP::CCS::Accuracy targetAccuracy;
-    MSP::CCS::CartesianCoordinates sourceCoordinates(
-        MSP::CCS::CoordinateType::geocentric, x, y, z);
-    MSP::CCS::GeodeticCoordinates targetCoordinates(
-        MSP::CCS::CoordinateType::geodetic, lon, lat, height);
+    MSP::CCS::GeodeticCoordinates sourceCoordinates(
+      MSP::CCS::CoordinateType::geodetic, lon, lat, height);
+    MSP::CCS::CartesianCoordinates targetCoordinates(
+      MSP::CCS::CoordinateType::geocentric);
 
-    ccsGeocentricToGeodeticMslEgm96.convertSourceToTarget(
-        &sourceCoordinates,
-        &sourceAccuracy,
-        targetCoordinates,
-        targetAccuracy);
+    ccsGeodeticEllipsoidToGeocentric.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
+      targetCoordinates,
+      targetAccuracy);
 
-    lat = targetCoordinates.latitude();
-    lon = targetCoordinates.longitude();
-    height = targetCoordinates.height();
+    x = targetCoordinates.x();
+    y = targetCoordinates.y();
+    z = targetCoordinates.z();
+  }
+  /**
+   * Function which uses the given Geocentric to MGRS Coordinate Conversion
+   * Service, 'ccsGeocentricToMgrs', to convert the given x, y, z coordinates
+   * to an MGRS string and precision.
+   **/
+std::string convertGeocentricToMgrs(
+  MSP::CCS::CoordinateConversionService & ccsGeocentricToMgrs,
+  double x,
+  double y,
+  double z,
+  MSP::CCS::Precision::Enum & precision) {
+  char * p;
+  std::string mgrsString;
+
+  MSP::CCS::Accuracy sourceAccuracy;
+  MSP::CCS::Accuracy targetAccuracy;
+  MSP::CCS::CartesianCoordinates sourceCoordinates(
+    MSP::CCS::CoordinateType::geocentric, x, y, z);
+  MSP::CCS::MGRSorUSNGCoordinates targetCoordinates;
+
+  ccsGeocentricToMgrs.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
+    targetCoordinates,
+    targetAccuracy);
+
+  // Returned value, 'p', points to targetCoordinate's internal character
+  // array so assign/copy the character array to mgrsString to avoid
+  // introducing memory management issues
+  p = targetCoordinates.MGRSString();
+  mgrsString = p;
+
+  precision = targetCoordinates.precision();
+
+  return mgrsString;
 }
 
 /**
@@ -58,91 +144,161 @@ void convertGeocentricToGeodeticMslEgm96(
  * to an MGRS string and precision.
  **/
 MSP::CCS::CartesianCoordinates convertGeocentricToMgrs(
-    MSP::CCS::CoordinateConversionService& ccsGeocentricToMgrs,
-    const char* mgrsString)
-{
+    MSP::CCS::CoordinateConversionService & ccsGeocentricToMgrs,
+    const char * mgrsString) {
     MSP::CCS::Accuracy sourceAccuracy;
     MSP::CCS::Accuracy targetAccuracy;
     MSP::CCS::MGRSorUSNGCoordinates sourceCoordinates(
-        MSP::CCS::CoordinateType::militaryGridReferenceSystem, mgrsString);
+      MSP::CCS::CoordinateType::militaryGridReferenceSystem, mgrsString);
     MSP::CCS::CartesianCoordinates targetCoordinates(
-        MSP::CCS::CoordinateType::geocentric);
+      MSP::CCS::CoordinateType::geocentric);
 
-    ccsGeocentricToMgrs.convertSourceToTarget(
-        &sourceCoordinates,
-        &sourceAccuracy,
-        targetCoordinates,
-        targetAccuracy);
+    ccsGeocentricToMgrs.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
+      targetCoordinates,
+      targetAccuracy);
     // Returned value, 'p', points to targetCoordinate's internal character
     // array so assign/copy the character array to mgrsString to avoid
     // introducing memory management issues
     return targetCoordinates;
+  }
+  /**
+   * Function to be wrapped with called by N-API function, taking in strings.
+   **/
+std::string convertMgrsToGeodetic(std::string mgrsCoordinateInput, std::string datumInput) {
+  double lat;
+  double lon;
+  const char * datum = datumInput.c_str();
+  const char * mgrsCoordinate = mgrsCoordinateInput.c_str();
+
+  //Parameter setup
+  MSP::CCS::GeodeticParameters mslEgm96Parameters(
+    MSP::CCS::CoordinateType::geodetic,
+    MSP::CCS::HeightType::EGM96FifteenMinBilinear);
+
+  MSP::CCS::CoordinateSystemParameters mgrsParameters(
+    MSP::CCS::CoordinateType::militaryGridReferenceSystem);
+
+  MSP::CCS::CoordinateSystemParameters geocentricParameters(
+    MSP::CCS::CoordinateType::geocentric);
+
+  MSP::CCS::CoordinateConversionService ccsGeocentricToMgrs(
+    datum, & mgrsParameters, datum, & geocentricParameters);
+
+  MSP::CCS::CoordinateConversionService ccsGeocentricToGeodeticMslEgm96(
+    datum, & geocentricParameters,
+    datum, & mslEgm96Parameters);
+
+  try {
+    MSP::CCS::CartesianCoordinates geocentricCoords = convertGeocentricToMgrs(ccsGeocentricToMgrs, mgrsCoordinate);
+    double mslHeight;
+
+    convertGeocentricToGeodeticMslEgm96(
+      ccsGeocentricToGeodeticMslEgm96,
+      geocentricCoords.x(), geocentricCoords.y(), geocentricCoords.z(),
+      lat, lon, mslHeight);
+  } catch (MSP::CCS::CoordinateConversionException & ex) {
+    std::string exceptionString(ex.getMessage());
+    std::string outputString = "ERROR: " + exceptionString;
+    return outputString;
+  } catch (...) {
+    std::string outputString = "ERROR: Unexpected exception encountered.";
+    return outputString;
+  }
+
+  std::string outputString = std::to_string(lat) + ", " + std::to_string(lon);
+  return outputString;
 }
 
 /**
  * Function to be wrapped with called by N-API function, taking in strings.
  **/
-std::string convertMgrsToGeodetic(std::string mgrsCoordinateInput, std::string datumInput)
-{
-    double lat;
-    double lon;
-    const char* datum = datumInput.c_str();
-    const char* mgrsCoordinate = mgrsCoordinateInput.c_str();
+std::string convertGeodeticToMgrs(double lat, double lon, double mslHeight, std::string datumInput) {
 
-    //Parameter setup
-    MSP::CCS::GeodeticParameters mslEgm96Parameters(
-        MSP::CCS::CoordinateType::geodetic,
-        MSP::CCS::HeightType::EGM96FifteenMinBilinear);
+  const char * datum = datumInput.c_str();
 
-    MSP::CCS::CoordinateSystemParameters mgrsParameters(
-        MSP::CCS::CoordinateType::militaryGridReferenceSystem);
+  //
+  // Coordinate System Parameters 
+  //
 
-    MSP::CCS::CoordinateSystemParameters geocentricParameters(
-        MSP::CCS::CoordinateType::geocentric);
+  MSP::CCS::GeodeticParameters mslEgm96Parameters(
+    MSP::CCS::CoordinateType::geodetic,
+    MSP::CCS::HeightType::EGM96FifteenMinBilinear);
 
-    MSP::CCS::CoordinateConversionService ccsGeocentricToMgrs(
-        datum, &mgrsParameters, datum, &geocentricParameters);
+  MSP::CCS::GeodeticParameters ellipsoidParameters(
+    MSP::CCS::CoordinateType::geodetic,
+    MSP::CCS::HeightType::ellipsoidHeight);
 
-    MSP::CCS::CoordinateConversionService ccsGeocentricToGeodeticMslEgm96(
-        datum, &geocentricParameters,
-        datum, &mslEgm96Parameters);
+  MSP::CCS::CoordinateSystemParameters geocentricParameters(
+    MSP::CCS::CoordinateType::geocentric);
 
-    try {
-        MSP::CCS::CartesianCoordinates geocentricCoords = convertGeocentricToMgrs(ccsGeocentricToMgrs, mgrsCoordinate);
-        double mslHeight;
+  MSP::CCS::CoordinateSystemParameters mgrsParameters(
+    MSP::CCS::CoordinateType::militaryGridReferenceSystem);
 
-        convertGeocentricToGeodeticMslEgm96(
-            ccsGeocentricToGeodeticMslEgm96,
-            geocentricCoords.x(), geocentricCoords.y(), geocentricCoords.z(),
-            lat, lon, mslHeight);
-    }
-    catch(MSP::CCS::CoordinateConversionException &ex) {
-        std::string exceptionString(ex.getMessage());
-        std::string outputString = "ERROR: " + exceptionString;
-        return outputString;
-    }
-    catch(...) {
-        std::string outputString = "ERROR: Unexpected exception encountered.";
-        return outputString;
-    }
+  MSP::CCS::CoordinateConversionService ccsMslEgm96ToEllipsoidHeight(
+    datum, & mslEgm96Parameters,
+    datum, & ellipsoidParameters);
 
-    std::string outputString = std::to_string(lat) + ", " + std::to_string(lon);
+  MSP::CCS::CoordinateConversionService ccsGeodeticEllipsoidToGeocentric(
+    datum, & ellipsoidParameters,
+    datum, & geocentricParameters);
+
+  MSP::CCS::CoordinateConversionService ccsGeocentricToMgrs(
+    datum, & geocentricParameters,
+    datum, & mgrsParameters);
+
+  std::string outputString;
+  try {
+    double x, y, z;
+    double height = 0.0;
+
+    convertMslEgm96ToEllipsoidHeight(
+      ccsMslEgm96ToEllipsoidHeight,
+      lat, lon, mslHeight,
+      height);
+
+    convertGeodeticEllipsoidToGeocentric(
+      ccsGeodeticEllipsoidToGeocentric,
+      lat, lon, height,
+      x, y, z);
+
+    MSP::CCS::Precision::Enum precision;
+
+    outputString = convertGeocentricToMgrs(
+      ccsGeocentricToMgrs,
+      x, y, z,
+      precision);
+  } catch (MSP::CCS::CoordinateConversionException & ex) {
+    std::string exceptionString(ex.getMessage());
+    std::string outputString = "ERROR: " + exceptionString;
     return outputString;
+  } catch (...) {
+    std::string outputString = "ERROR: Unexpected exception encountered.";
+    return outputString;
+  }
+  return outputString;
+
 }
 
 /**
  * Function to be called by N-API function. Arguments passed from init function.
  **/
-String callConvertToGeodetic(const CallbackInfo& info)
-{
-    return String::New(info.Env(), convertMgrsToGeodetic(info[0].As<String>().Utf8Value(), info[1].As<String>().Utf8Value()));
+String callConvertToGeodetic(const CallbackInfo & info) {
+  return String::New(info.Env(), convertMgrsToGeodetic(info[0].As < String > ().Utf8Value(), info[1].As < String > ().Utf8Value()));
+}
+
+/**
+ * Function to be called by N-API function. Arguments passed from init function.
+ **/
+String callConvertToMgrs(const CallbackInfo & info) {
+  return String::New(info.Env(), convertGeodeticToMgrs(info[0].As < Number > (), info[1].As < Number > (), info[2].As < Number > (), info[3].As < String > ().Utf8Value()));
 }
 
 /**
  * Initializer
  **/
-void Init(Env env, Object exports, Object module)
-{
-    exports.Set("callConvertToGeodetic", Function::New(env, callConvertToGeodetic));
+void Init(Env env, Object exports, Object module) {
+  exports.Set("callConvertToGeodetic", Function::New(env, callConvertToGeodetic));
+  exports.Set("callConvertToMgrs", Function::New(env, callConvertToMgrs));
+
 }
 NODE_API_MODULE(addon, Init);

--- a/geotrans3.7/CCS/sampleCode/mgrsToGeodetic.cpp
+++ b/geotrans3.7/CCS/sampleCode/mgrsToGeodetic.cpp
@@ -29,17 +29,18 @@ std::string convertMgrsToGeodetic(std::string mgrs, std::string datumInput) {
 
   MSP::CCS::GeodeticParameters geodeticParameters(
     MSP::CCS::CoordinateType::geodetic,
-    MSP::CCS::HeightType::ellipsoidHeight);
+    MSP::CCS::HeightType::noHeight);
 
   MSP::CCS::GeodeticParameters ellipsoidParameters(
     MSP::CCS::CoordinateType::geodetic,
-    MSP::CCS::HeightType::ellipsoidHeight);
+    MSP::CCS::HeightType::noHeight);
 
   MSP::CCS::CoordinateSystemParameters mgrsParameters(
     MSP::CCS::CoordinateType::militaryGridReferenceSystem);
 
   MSP::CCS::CoordinateSystemParameters geocentricParameters(
     MSP::CCS::CoordinateType::geocentric);
+
 
   MSP::CCS::CoordinateConversionService ccsGeocentricToMgrs(
     datum, & mgrsParameters, datum, & geocentricParameters);
@@ -89,7 +90,7 @@ std::string convertGeodeticToMgrs(double lat, double lon, double mslHeight, std:
 
   MSP::CCS::GeodeticParameters ellipsoidParameters(
     MSP::CCS::CoordinateType::geodetic,
-    MSP::CCS::HeightType::ellipsoidHeight);
+    MSP::CCS::HeightType::noHeight);
 
   MSP::CCS::CoordinateSystemParameters geocentricParameters(
     MSP::CCS::CoordinateType::geocentric);

--- a/geotrans3.7/CCS/sampleCode/mgrsToGeodetic.cpp
+++ b/geotrans3.7/CCS/sampleCode/mgrsToGeodetic.cpp
@@ -1,3 +1,4 @@
+
 #include <napi.h>
 #include <ctime>
 #include <cerrno>
@@ -26,13 +27,13 @@ using namespace Napi;
  * convert the given x, y, z coordinates to a lat, lon, and height.
  **/
 void convertGeocentricToEllipsoidHeight(
-  MSP::CCS::CoordinateConversionService& ccsGeocentricToEllipsoidHeight,
+  MSP::CCS::CoordinateConversionService & ccsGeocentricToEllipsoidHeight,
   double x,
   double y,
   double z,
-  double& lat,
-  double& lon,
-  double& height) {
+  double & lat,
+  double & lon,
+  double & height) {
   MSP::CCS::Accuracy sourceAccuracy;
   MSP::CCS::Accuracy targetAccuracy;
   MSP::CCS::CartesianCoordinates sourceCoordinates(
@@ -40,7 +41,7 @@ void convertGeocentricToEllipsoidHeight(
   MSP::CCS::GeodeticCoordinates targetCoordinates(
     MSP::CCS::CoordinateType::geodetic, lon, lat, height);
 
-  ccsGeocentricToEllipsoidHeight.convertSourceToTarget( &sourceCoordinates, &sourceAccuracy,
+  ccsGeocentricToEllipsoidHeight.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
     targetCoordinates,
     targetAccuracy);
 
@@ -50,18 +51,43 @@ void convertGeocentricToEllipsoidHeight(
 }
 
 /**
+ * Function which uses the given Geodetic (MSL EGM 96 15M) to Geodetic
+ * (Ellipsoid Height) Coordinate Conversion Service,
+ * 'ccsMslEgm96ToEllipsoidHeight', to convert the given MSL height at the
+ * given lat, lon, to an Ellipsoid height.
+ **/
+void convertMslEgm96ToEllipsoidHeight(
+  MSP::CCS::CoordinateConversionService & ccsMslEgm96ToEllipsoidHeight,
+  double lat,
+  double lon,
+  double mslHeight,
+  double & ellipsoidHeight) {
+  MSP::CCS::Accuracy sourceAccuracy;
+  MSP::CCS::Accuracy targetAccuracy;
+  MSP::CCS::GeodeticCoordinates sourceCoordinates(
+    MSP::CCS::CoordinateType::geodetic, lon, lat, mslHeight);
+  MSP::CCS::GeodeticCoordinates targetCoordinates;
+
+  ccsMslEgm96ToEllipsoidHeight.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
+    targetCoordinates,
+    targetAccuracy);
+
+  ellipsoidHeight = targetCoordinates.height();
+}
+
+/**
  * Function which uses the given Geodetic (Ellipsoid Height) to Geocentric 
  * Coordinate Conversion Service, 'ccsGeodeticEllipsoidToGeocentric', to
  * convert the given lat, lon, and height to x, y, z coordinates.
  **/
 void convertGeodeticEllipsoidToGeocentric(
-    MSP::CCS::CoordinateConversionService& ccsGeodeticEllipsoidToGeocentric,
+    MSP::CCS::CoordinateConversionService & ccsGeodeticEllipsoidToGeocentric,
     double lat,
     double lon,
     double height,
-    double& x,
-    double& y,
-    double& z) {
+    double & x,
+    double & y,
+    double & z) {
     MSP::CCS::Accuracy sourceAccuracy;
     MSP::CCS::Accuracy targetAccuracy;
     MSP::CCS::GeodeticCoordinates sourceCoordinates(
@@ -69,7 +95,7 @@ void convertGeodeticEllipsoidToGeocentric(
     MSP::CCS::CartesianCoordinates targetCoordinates(
       MSP::CCS::CoordinateType::geocentric);
 
-    ccsGeodeticEllipsoidToGeocentric.convertSourceToTarget( &sourceCoordinates, &sourceAccuracy,
+    ccsGeodeticEllipsoidToGeocentric.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
       targetCoordinates,
       targetAccuracy);
 
@@ -83,12 +109,12 @@ void convertGeodeticEllipsoidToGeocentric(
    * to an MGRS string and precision.
    **/
 std::string convertGeocentricToMgrs(
-  MSP::CCS::CoordinateConversionService& ccsGeocentricToMgrs,
+  MSP::CCS::CoordinateConversionService & ccsGeocentricToMgrs,
   double x,
   double y,
   double z,
-  MSP::CCS::Precision::Enum& precision) {
-  char* p;
+  MSP::CCS::Precision::Enum & precision) {
+  char * p;
   std::string mgrsString;
 
   MSP::CCS::Accuracy sourceAccuracy;
@@ -97,7 +123,7 @@ std::string convertGeocentricToMgrs(
     MSP::CCS::CoordinateType::geocentric, x, y, z);
   MSP::CCS::MGRSorUSNGCoordinates targetCoordinates;
 
-  ccsGeocentricToMgrs.convertSourceToTarget( &sourceCoordinates, &sourceAccuracy,
+  ccsGeocentricToMgrs.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
     targetCoordinates,
     targetAccuracy);
 
@@ -107,6 +133,8 @@ std::string convertGeocentricToMgrs(
   p = targetCoordinates.MGRSString();
   mgrsString = p;
 
+  precision = targetCoordinates.precision();
+
   return mgrsString;
 }
 
@@ -115,9 +143,9 @@ std::string convertGeocentricToMgrs(
  * Service, 'ccsGeocentricToMgrs', to convert the given x, y, z coordinates
  * to an MGRS string and precision.
  **/
-MSP::CCS::CartesianCoordinates convertMgrsToGeocentric(
-    MSP::CCS::CoordinateConversionService& ccsGeocentricToMgrs,
-    const char* mgrsString) {
+MSP::CCS::CartesianCoordinates convertGeocentricToMgrs(
+    MSP::CCS::CoordinateConversionService & ccsGeocentricToMgrs,
+    const char * mgrsString) {
     MSP::CCS::Accuracy sourceAccuracy;
     MSP::CCS::Accuracy targetAccuracy;
     MSP::CCS::MGRSorUSNGCoordinates sourceCoordinates(
@@ -125,7 +153,7 @@ MSP::CCS::CartesianCoordinates convertMgrsToGeocentric(
     MSP::CCS::CartesianCoordinates targetCoordinates(
       MSP::CCS::CoordinateType::geocentric);
 
-    ccsGeocentricToMgrs.convertSourceToTarget( &sourceCoordinates, &sourceAccuracy,
+    ccsGeocentricToMgrs.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
       targetCoordinates,
       targetAccuracy);
     // Returned value, 'p', points to targetCoordinate's internal character
@@ -140,8 +168,8 @@ std::string convertMgrsToGeodetic(std::string mgrsCoordinateInput, std::string d
   double lat;
   double lon;
   double mslHeight;
-  const char* datum = datumInput.c_str();
-  const char* mgrsCoordinate = mgrsCoordinateInput.c_str();
+  const char * datum = datumInput.c_str();
+  const char * mgrsCoordinate = mgrsCoordinateInput.c_str();
 
   //Parameter setup
   MSP::CCS::GeodeticParameters geodeticParameters(
@@ -160,21 +188,21 @@ std::string convertMgrsToGeodetic(std::string mgrsCoordinateInput, std::string d
     MSP::CCS::CoordinateType::geocentric);
 
   MSP::CCS::CoordinateConversionService ccsGeocentricToMgrs(
-    datum, &mgrsParameters, datum, &geocentricParameters);
+    datum, & mgrsParameters, datum, & geocentricParameters);
 
   MSP::CCS::CoordinateConversionService ccsGeocentricToEllipsoidHeight(
-    datum, &geocentricParameters,
-    datum, &ellipsoidParameters);
+    datum, & geocentricParameters,
+    datum, & ellipsoidParameters);
 
   
   try {
-    MSP::CCS::CartesianCoordinates geocentricCoords = convertMgrsToGeocentric(ccsGeocentricToMgrs, mgrsCoordinate);
+    MSP::CCS::CartesianCoordinates geocentricCoords = convertGeocentricToMgrs(ccsGeocentricToMgrs, mgrsCoordinate);
 
     convertGeocentricToEllipsoidHeight(
       ccsGeocentricToEllipsoidHeight,
       geocentricCoords.x(), geocentricCoords.y(), geocentricCoords.z(),
       lat, lon, mslHeight);
-  } catch (MSP::CCS::CoordinateConversionException& ex) {
+  } catch (MSP::CCS::CoordinateConversionException & ex) {
     std::string exceptionString(ex.getMessage());
     std::string outputString = "ERROR: " + exceptionString;
     return outputString;
@@ -190,14 +218,10 @@ std::string convertMgrsToGeodetic(std::string mgrsCoordinateInput, std::string d
 /**
  * Function to be wrapped with called by N-API function, taking in strings.
  **/
-std::string convertGeodeticToMgrs(
-  double lat, 
-  double lon, 
-  double mslHeight,
-  std::string datumInput) {
+std::string convertGeodeticToMgrs(double lat, double lon, double mslHeight, std::string datumInput) {
 
-  const char* datum = datumInput.c_str();
-  std::string outputString;
+  const char * datum = datumInput.c_str();
+
   //
   // Coordinate System Parameters 
   //
@@ -213,14 +237,14 @@ std::string convertGeodeticToMgrs(
     MSP::CCS::CoordinateType::militaryGridReferenceSystem);
 
   MSP::CCS::CoordinateConversionService ccsGeodeticEllipsoidToGeocentric(
-    datum, &ellipsoidParameters,
-    datum, &geocentricParameters);
+    datum, & ellipsoidParameters,
+    datum, & geocentricParameters);
 
   MSP::CCS::CoordinateConversionService ccsGeocentricToMgrs(
-    datum, &geocentricParameters,
-    datum, &mgrsParameters);
+    datum, & geocentricParameters,
+    datum, & mgrsParameters);
 
-
+  std::string outputString;
   try {
     double x = 0.0; 
     double y = 0.0; 
@@ -234,12 +258,11 @@ std::string convertGeodeticToMgrs(
 
     MSP::CCS::Precision::Enum precision;
 
-    std::string outputString = convertGeocentricToMgrs(
+    outputString = convertGeocentricToMgrs(
       ccsGeocentricToMgrs,
       x, y, z,
       precision);
-    
-  } catch (MSP::CCS::CoordinateConversionException& ex) {
+  } catch (MSP::CCS::CoordinateConversionException & ex) {
     std::string exceptionString(ex.getMessage());
     std::string outputString = "ERROR: " + exceptionString;
     return outputString;
@@ -247,7 +270,6 @@ std::string convertGeodeticToMgrs(
     std::string outputString = "ERROR: Unexpected exception encountered.";
     return outputString;
   }
-  
   return outputString;
 
 }

--- a/geotrans3.7/CCS/sampleCode/mgrsToGeodetic.cpp
+++ b/geotrans3.7/CCS/sampleCode/mgrsToGeodetic.cpp
@@ -4,7 +4,7 @@
 #include <cerrno>
 #include <iostream>
 #include <string>
-
+#include <math.h>
 #include "CoordinateConversionService.h"
 #include "CoordinateSystemParameters.h"
 #include "GeodeticParameters.h"
@@ -22,7 +22,7 @@
 using namespace Napi;
 
 /**
- * Function which uses the given Geocentric to Geodetic (MSL EGM 96 15M)
+ * Function which uses the given Geocentric to Geodetic (Ellipsoid)
  * Coordinate Conversion Service, 'ccsGeocentricToGeodeticMslEgm96', to
  * convert the given x, y, z coordinates to a lat, lon, and height.
  **/
@@ -48,31 +48,6 @@ void convertGeocentricToEllipsoidHeight(
   lat = targetCoordinates.latitude();
   lon = targetCoordinates.longitude();
   height = targetCoordinates.height();
-}
-
-/**
- * Function which uses the given Geodetic (MSL EGM 96 15M) to Geodetic
- * (Ellipsoid Height) Coordinate Conversion Service,
- * 'ccsMslEgm96ToEllipsoidHeight', to convert the given MSL height at the
- * given lat, lon, to an Ellipsoid height.
- **/
-void convertMslEgm96ToEllipsoidHeight(
-  MSP::CCS::CoordinateConversionService & ccsMslEgm96ToEllipsoidHeight,
-  double lat,
-  double lon,
-  double mslHeight,
-  double & ellipsoidHeight) {
-  MSP::CCS::Accuracy sourceAccuracy;
-  MSP::CCS::Accuracy targetAccuracy;
-  MSP::CCS::GeodeticCoordinates sourceCoordinates(
-    MSP::CCS::CoordinateType::geodetic, lon, lat, mslHeight);
-  MSP::CCS::GeodeticCoordinates targetCoordinates;
-
-  ccsMslEgm96ToEllipsoidHeight.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
-    targetCoordinates,
-    targetAccuracy);
-
-  ellipsoidHeight = targetCoordinates.height();
 }
 
 /**
@@ -143,7 +118,7 @@ std::string convertGeocentricToMgrs(
  * Service, 'ccsGeocentricToMgrs', to convert the given x, y, z coordinates
  * to an MGRS string and precision.
  **/
-MSP::CCS::CartesianCoordinates convertGeocentricToMgrs(
+MSP::CCS::CartesianCoordinates convertMgrsGeocentric(
     MSP::CCS::CoordinateConversionService & ccsGeocentricToMgrs,
     const char * mgrsString) {
     MSP::CCS::Accuracy sourceAccuracy;
@@ -196,7 +171,7 @@ std::string convertMgrsToGeodetic(std::string mgrsCoordinateInput, std::string d
 
   
   try {
-    MSP::CCS::CartesianCoordinates geocentricCoords = convertGeocentricToMgrs(ccsGeocentricToMgrs, mgrsCoordinate);
+    MSP::CCS::CartesianCoordinates geocentricCoords = convertMgrsGeocentric(ccsGeocentricToMgrs, mgrsCoordinate);
 
     convertGeocentricToEllipsoidHeight(
       ccsGeocentricToEllipsoidHeight,

--- a/geotrans3.7/CCS/sampleCode/mgrsToGeodetic.cpp
+++ b/geotrans3.7/CCS/sampleCode/mgrsToGeodetic.cpp
@@ -1,4 +1,3 @@
-
 #include <napi.h>
 #include <ctime>
 #include <cerrno>
@@ -27,13 +26,13 @@ using namespace Napi;
  * convert the given x, y, z coordinates to a lat, lon, and height.
  **/
 void convertGeocentricToEllipsoidHeight(
-  MSP::CCS::CoordinateConversionService & ccsGeocentricToEllipsoidHeight,
+  MSP::CCS::CoordinateConversionService& ccsGeocentricToEllipsoidHeight,
   double x,
   double y,
   double z,
-  double & lat,
-  double & lon,
-  double & height) {
+  double& lat,
+  double& lon,
+  double& height) {
   MSP::CCS::Accuracy sourceAccuracy;
   MSP::CCS::Accuracy targetAccuracy;
   MSP::CCS::CartesianCoordinates sourceCoordinates(
@@ -41,7 +40,7 @@ void convertGeocentricToEllipsoidHeight(
   MSP::CCS::GeodeticCoordinates targetCoordinates(
     MSP::CCS::CoordinateType::geodetic, lon, lat, height);
 
-  ccsGeocentricToEllipsoidHeight.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
+  ccsGeocentricToEllipsoidHeight.convertSourceToTarget( &sourceCoordinates, &sourceAccuracy,
     targetCoordinates,
     targetAccuracy);
 
@@ -51,43 +50,18 @@ void convertGeocentricToEllipsoidHeight(
 }
 
 /**
- * Function which uses the given Geodetic (MSL EGM 96 15M) to Geodetic
- * (Ellipsoid Height) Coordinate Conversion Service,
- * 'ccsMslEgm96ToEllipsoidHeight', to convert the given MSL height at the
- * given lat, lon, to an Ellipsoid height.
- **/
-void convertMslEgm96ToEllipsoidHeight(
-  MSP::CCS::CoordinateConversionService & ccsMslEgm96ToEllipsoidHeight,
-  double lat,
-  double lon,
-  double mslHeight,
-  double & ellipsoidHeight) {
-  MSP::CCS::Accuracy sourceAccuracy;
-  MSP::CCS::Accuracy targetAccuracy;
-  MSP::CCS::GeodeticCoordinates sourceCoordinates(
-    MSP::CCS::CoordinateType::geodetic, lon, lat, mslHeight);
-  MSP::CCS::GeodeticCoordinates targetCoordinates;
-
-  ccsMslEgm96ToEllipsoidHeight.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
-    targetCoordinates,
-    targetAccuracy);
-
-  ellipsoidHeight = targetCoordinates.height();
-}
-
-/**
  * Function which uses the given Geodetic (Ellipsoid Height) to Geocentric 
  * Coordinate Conversion Service, 'ccsGeodeticEllipsoidToGeocentric', to
  * convert the given lat, lon, and height to x, y, z coordinates.
  **/
 void convertGeodeticEllipsoidToGeocentric(
-    MSP::CCS::CoordinateConversionService & ccsGeodeticEllipsoidToGeocentric,
+    MSP::CCS::CoordinateConversionService& ccsGeodeticEllipsoidToGeocentric,
     double lat,
     double lon,
     double height,
-    double & x,
-    double & y,
-    double & z) {
+    double& x,
+    double& y,
+    double& z) {
     MSP::CCS::Accuracy sourceAccuracy;
     MSP::CCS::Accuracy targetAccuracy;
     MSP::CCS::GeodeticCoordinates sourceCoordinates(
@@ -95,7 +69,7 @@ void convertGeodeticEllipsoidToGeocentric(
     MSP::CCS::CartesianCoordinates targetCoordinates(
       MSP::CCS::CoordinateType::geocentric);
 
-    ccsGeodeticEllipsoidToGeocentric.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
+    ccsGeodeticEllipsoidToGeocentric.convertSourceToTarget( &sourceCoordinates, &sourceAccuracy,
       targetCoordinates,
       targetAccuracy);
 
@@ -109,12 +83,12 @@ void convertGeodeticEllipsoidToGeocentric(
    * to an MGRS string and precision.
    **/
 std::string convertGeocentricToMgrs(
-  MSP::CCS::CoordinateConversionService & ccsGeocentricToMgrs,
+  MSP::CCS::CoordinateConversionService& ccsGeocentricToMgrs,
   double x,
   double y,
   double z,
-  MSP::CCS::Precision::Enum & precision) {
-  char * p;
+  MSP::CCS::Precision::Enum& precision) {
+  char* p;
   std::string mgrsString;
 
   MSP::CCS::Accuracy sourceAccuracy;
@@ -123,7 +97,7 @@ std::string convertGeocentricToMgrs(
     MSP::CCS::CoordinateType::geocentric, x, y, z);
   MSP::CCS::MGRSorUSNGCoordinates targetCoordinates;
 
-  ccsGeocentricToMgrs.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
+  ccsGeocentricToMgrs.convertSourceToTarget( &sourceCoordinates, &sourceAccuracy,
     targetCoordinates,
     targetAccuracy);
 
@@ -133,8 +107,6 @@ std::string convertGeocentricToMgrs(
   p = targetCoordinates.MGRSString();
   mgrsString = p;
 
-  precision = targetCoordinates.precision();
-
   return mgrsString;
 }
 
@@ -143,8 +115,8 @@ std::string convertGeocentricToMgrs(
  * Service, 'ccsGeocentricToMgrs', to convert the given x, y, z coordinates
  * to an MGRS string and precision.
  **/
-MSP::CCS::CartesianCoordinates convertGeocentricToMgrs(
-    MSP::CCS::CoordinateConversionService & ccsGeocentricToMgrs,
+MSP::CCS::CartesianCoordinates convertMgrsToGeocentric(
+    MSP::CCS::CoordinateConversionService& ccsGeocentricToMgrs,
     const char * mgrsString) {
     MSP::CCS::Accuracy sourceAccuracy;
     MSP::CCS::Accuracy targetAccuracy;
@@ -153,7 +125,7 @@ MSP::CCS::CartesianCoordinates convertGeocentricToMgrs(
     MSP::CCS::CartesianCoordinates targetCoordinates(
       MSP::CCS::CoordinateType::geocentric);
 
-    ccsGeocentricToMgrs.convertSourceToTarget( & sourceCoordinates, & sourceAccuracy,
+    ccsGeocentricToMgrs.convertSourceToTarget( &sourceCoordinates, &sourceAccuracy,
       targetCoordinates,
       targetAccuracy);
     // Returned value, 'p', points to targetCoordinate's internal character
@@ -168,8 +140,8 @@ std::string convertMgrsToGeodetic(std::string mgrsCoordinateInput, std::string d
   double lat;
   double lon;
   double mslHeight;
-  const char * datum = datumInput.c_str();
-  const char * mgrsCoordinate = mgrsCoordinateInput.c_str();
+  const char* datum = datumInput.c_str();
+  const char* mgrsCoordinate = mgrsCoordinateInput.c_str();
 
   //Parameter setup
   MSP::CCS::GeodeticParameters geodeticParameters(
@@ -188,21 +160,21 @@ std::string convertMgrsToGeodetic(std::string mgrsCoordinateInput, std::string d
     MSP::CCS::CoordinateType::geocentric);
 
   MSP::CCS::CoordinateConversionService ccsGeocentricToMgrs(
-    datum, & mgrsParameters, datum, & geocentricParameters);
+    datum, &mgrsParameters, datum, &geocentricParameters);
 
   MSP::CCS::CoordinateConversionService ccsGeocentricToEllipsoidHeight(
-    datum, & geocentricParameters,
-    datum, & ellipsoidParameters);
+    datum, &geocentricParameters,
+    datum, &ellipsoidParameters);
 
   
   try {
-    MSP::CCS::CartesianCoordinates geocentricCoords = convertGeocentricToMgrs(ccsGeocentricToMgrs, mgrsCoordinate);
+    MSP::CCS::CartesianCoordinates geocentricCoords = convertMgrsToGeocentric(ccsGeocentricToMgrs, mgrsCoordinate);
 
     convertGeocentricToEllipsoidHeight(
       ccsGeocentricToEllipsoidHeight,
       geocentricCoords.x(), geocentricCoords.y(), geocentricCoords.z(),
       lat, lon, mslHeight);
-  } catch (MSP::CCS::CoordinateConversionException & ex) {
+  } catch (MSP::CCS::CoordinateConversionException& ex) {
     std::string exceptionString(ex.getMessage());
     std::string outputString = "ERROR: " + exceptionString;
     return outputString;
@@ -220,8 +192,8 @@ std::string convertMgrsToGeodetic(std::string mgrsCoordinateInput, std::string d
  **/
 std::string convertGeodeticToMgrs(double lat, double lon, double mslHeight, std::string datumInput) {
 
-  const char * datum = datumInput.c_str();
-
+  const char* datum = datumInput.c_str();
+  std::string outputString;
   //
   // Coordinate System Parameters 
   //
@@ -237,14 +209,14 @@ std::string convertGeodeticToMgrs(double lat, double lon, double mslHeight, std:
     MSP::CCS::CoordinateType::militaryGridReferenceSystem);
 
   MSP::CCS::CoordinateConversionService ccsGeodeticEllipsoidToGeocentric(
-    datum, & ellipsoidParameters,
-    datum, & geocentricParameters);
+    datum, &ellipsoidParameters,
+    datum, &geocentricParameters);
 
   MSP::CCS::CoordinateConversionService ccsGeocentricToMgrs(
-    datum, & geocentricParameters,
-    datum, & mgrsParameters);
+    datum, &geocentricParameters,
+    datum, &mgrsParameters);
 
-  std::string outputString;
+
   try {
     double x = 0.0; 
     double y = 0.0; 
@@ -258,11 +230,12 @@ std::string convertGeodeticToMgrs(double lat, double lon, double mslHeight, std:
 
     MSP::CCS::Precision::Enum precision;
 
-    outputString = convertGeocentricToMgrs(
+    std::string outputString = convertGeocentricToMgrs(
       ccsGeocentricToMgrs,
       x, y, z,
       precision);
-  } catch (MSP::CCS::CoordinateConversionException & ex) {
+    
+  } catch (MSP::CCS::CoordinateConversionException& ex) {
     std::string exceptionString(ex.getMessage());
     std::string outputString = "ERROR: " + exceptionString;
     return outputString;
@@ -270,6 +243,7 @@ std::string convertGeodeticToMgrs(double lat, double lon, double mslHeight, std:
     std::string outputString = "ERROR: Unexpected exception encountered.";
     return outputString;
   }
+  
   return outputString;
 
 }
@@ -277,15 +251,15 @@ std::string convertGeodeticToMgrs(double lat, double lon, double mslHeight, std:
 /**
  * Function to be called by N-API function. Arguments passed from init function.
  **/
-String callConvertToGeodetic(const CallbackInfo & info) {
-  return String::New(info.Env(), convertMgrsToGeodetic(info[0].As < String > ().Utf8Value(), info[1].As < String > ().Utf8Value()));
+String callConvertToGeodetic(const CallbackInfo& info) {
+  return String::New(info.Env(), convertMgrsToGeodetic(info[0].As<String>().Utf8Value(), info[1].As<String>().Utf8Value()));
 }
 
 /**
  * Function to be called by N-API function. Arguments passed from init function.
  **/
-String callConvertToMgrs(const CallbackInfo & info) {
-  return String::New(info.Env(), convertGeodeticToMgrs(info[0].As < Number > (), info[1].As < Number > (), info[2].As < Number > (), info[3].As < String > ().Utf8Value()));
+String callConvertToMgrs(const CallbackInfo& info) {
+  return String::New(info.Env(), convertGeodeticToMgrs(info[0].As<Number>(), info[1].As<Number>(), info[2].As<Number>(), info[3].As<String>().Utf8Value()));
 }
 
 /**
@@ -294,6 +268,5 @@ String callConvertToMgrs(const CallbackInfo & info) {
 void Init(Env env, Object exports, Object module) {
   exports.Set("callConvertToGeodetic", Function::New(env, callConvertToGeodetic));
   exports.Set("callConvertToMgrs", Function::New(env, callConvertToMgrs));
-
 }
 NODE_API_MODULE(addon, Init);

--- a/geotrans3.7/CCS/sampleCode/mgrsToGeodetic.cpp
+++ b/geotrans3.7/CCS/sampleCode/mgrsToGeodetic.cpp
@@ -117,7 +117,7 @@ std::string convertGeocentricToMgrs(
  **/
 MSP::CCS::CartesianCoordinates convertMgrsToGeocentric(
     MSP::CCS::CoordinateConversionService& ccsGeocentricToMgrs,
-    const char * mgrsString) {
+    const char* mgrsString) {
     MSP::CCS::Accuracy sourceAccuracy;
     MSP::CCS::Accuracy targetAccuracy;
     MSP::CCS::MGRSorUSNGCoordinates sourceCoordinates(
@@ -190,7 +190,11 @@ std::string convertMgrsToGeodetic(std::string mgrsCoordinateInput, std::string d
 /**
  * Function to be wrapped with called by N-API function, taking in strings.
  **/
-std::string convertGeodeticToMgrs(double lat, double lon, double mslHeight, std::string datumInput) {
+std::string convertGeodeticToMgrs(
+  double lat, 
+  double lon, 
+  double mslHeight,
+  std::string datumInput) {
 
   const char* datum = datumInput.c_str();
   std::string outputString;

--- a/geotransMgrsConverter.js
+++ b/geotransMgrsConverter.js
@@ -51,7 +51,7 @@ class MgrsConverter {
 
     decDegToMgrs(latitude, longitude){
         if((latitude > -90 && latitude < 90) && (longitude > -180 && longitude < 180) && this._datum){
-            let conversionResult = require("./build/Release/native.node").callConvertToMgrs(this.constructor.degreesToRadians(latitude), this.constructor.degreesToRadians(longitude), 1, this._datum);
+            let conversionResult = require("./build/Release/native.node").callConvertToMgrs(this.constructor.degreesToRadians(latitude), this.constructor.degreesToRadians(longitude), 0, this._datum);
             return this.constructor.generateJSON(conversionResult, latitude, longitude);
         }
         else{

--- a/geotransMgrsConverter.js
+++ b/geotransMgrsConverter.js
@@ -21,7 +21,7 @@ class MgrsConverter {
      * @param {string} mgrsString - Alpha-numeric system for expressing UTM / UPS coordinates.
      */
     mgrsToDecDeg(mgrsString){
-        let latitude, longitude;
+        let latitude, longitude, height;
         mgrsString = this.constructor.sanitize(mgrsString);
         if(mgrsString && this._datum && this.constructor.isValid(mgrsString)){
             let conversionResult = require("./build/Release/native.node").callConvertToGeodetic(mgrsString, this._datum);

--- a/geotransMgrsConverter.js
+++ b/geotransMgrsConverter.js
@@ -32,8 +32,8 @@ class MgrsConverter {
                 return conversionResult;
             } else {
                 //process successful result
-                latitude = this.constructor.radiansToDegrees(convertedCoords[0]);
-                longitude = this.constructor.radiansToDegrees(convertedCoords[1]);
+                latitude = this.constructor.precisionRound(this.constructor.radiansToDegrees(convertedCoords[0]), 5);
+                longitude = this.constructor.precisionRound(this.constructor.radiansToDegrees(convertedCoords[1]), 5);
                 return this.constructor.generateJSON(mgrsString, latitude, longitude);
             }
         }
@@ -50,15 +50,32 @@ class MgrsConverter {
     }
 
     decDegToMgrs(latitude, longitude){
+        latitude = this.constructor.precisionRound(latitude, 5);
+        longitude = this.constructor.precisionRound(longitude, 5);
         if((latitude > -90 && latitude < 90) && (longitude > -180 && longitude < 180) && this._datum){
-            let conversionResult = require("./build/Release/native.node").callConvertToMgrs(this.constructor.degreesToRadians(latitude), this.constructor.degreesToRadians(longitude), 0, this._datum);
+            let conversionResult = require("./build/Release/native.node").callConvertToMgrs(
+                this.constructor.degreesToRadians(latitude), 
+                this.constructor.degreesToRadians(longitude), 
+                0, 
+                this._datum);
+
             return this.constructor.generateJSON(conversionResult, latitude, longitude);
         }
         else{
             return "ERROR: Invalid Coordinate";
         }
     }
-
+    /**
+    * Emulate rounding to the same precision as the Geotrans Java spp.
+    * @param {number} radians 
+    */
+    static precisionRound(number, precision) {
+        var shift = function (number, precision) {
+          var numArray = ("" + number).split("e");
+          return +(numArray[0] + "e" + (numArray[1] ? (+numArray[1] + precision) : precision));
+        };
+        return shift(Math.round(shift(number, +precision)), -precision).toFixed(precision);
+    }
     
     /**
     * Simple converter from radians to degrees.
@@ -84,7 +101,7 @@ class MgrsConverter {
             'type':'Feature',
             'geometry':{
                 'type':'Point',
-                'coordinates': [longitude, latitude]
+                'coordinates': [parseFloat(longitude), parseFloat(latitude)]
             },
             'properties':{
                 'name':mgrsString

--- a/geotransMgrsConverter.js
+++ b/geotransMgrsConverter.js
@@ -20,11 +20,11 @@ class MgrsConverter {
      * Convert function. Primary usage of this module.
      * @param {string} mgrsString - Alpha-numeric system for expressing UTM / UPS coordinates.
      */
-    convert(mgrsString){
+    mgrsToDecDeg(mgrsString){
         let latitude, longitude;
         mgrsString = this.constructor.sanitize(mgrsString);
         if(mgrsString && this._datum && this.constructor.isValid(mgrsString)){
-            let conversionResult = this.callLibrary(mgrsString)
+            let conversionResult = require("./build/Release/native.node").callConvertToGeodetic(mgrsString, this._datum);
             let convertedCoords = conversionResult.split(',');
             
             if(!convertedCoords[0]||!convertedCoords[1]){
@@ -49,6 +49,16 @@ class MgrsConverter {
         }
     }
 
+    decDegToMgrs(latitude, longitude){
+        if((latitude > -90 && latitude < 90) && (longitude > -180 && longitude < 180) && this._datum){
+            let conversionResult = require("./build/Release/native.node").callConvertToMgrs(this.constructor.degreesToRadians(latitude), this.constructor.degreesToRadians(longitude), 1, this._datum);
+            return this.constructor.generateJSON(conversionResult, latitude, longitude);
+        }
+        else{
+            return "ERROR: Invalid Coordinate";
+        }
+    }
+
     
     /**
     * Simple converter from radians to degrees.
@@ -58,6 +68,14 @@ class MgrsConverter {
        let pi = Math.PI;
        return radians * (180/pi);
     }
+    /**
+    * Simple converter from degrees to radians.
+    * @param {number} degrees 
+    */
+    static degreesToRadians(degrees){
+        let pi = Math.PI;
+        return degrees * (pi/180);
+     }
     /**
      * GeoJSON Point generator
      */
@@ -101,13 +119,6 @@ class MgrsConverter {
     static sanitize(mgrsString){
         mgrsString.toUpperCase();
         return mgrsString.replace(/\s+/g, '');
-    }
-    /**
-    * Calls C++ function "convertToGeodetic" in mgrsToGeodetic. Values passed in from 'convert' function above.
-    * @param {string} mgrsString
-    */
-    callLibrary(mgrsString){ 
-        return require("./build/Release/native.node").callConvertToGeodetic(mgrsString, this._datum);
     }
 }
 

--- a/geotransMgrsConverter.spec.js
+++ b/geotransMgrsConverter.spec.js
@@ -17,27 +17,51 @@ describe("Geotrans MGRS Converter Tests", ()=>{
         };
 
         it("should return expected valid GeoJSON", ()=> {
-            expect(converterInstance.convert("18TXM9963493438")).toEqual(validReturn);
+            expect(converterInstance.mgrsToDecDeg("18TXM9963493438")).toEqual(validReturn);
         });
     });
     describe("A shorthand MGRS coordinate returns the same thing as a more precise counterpart", () => {
         it("should return expected valid GeoJSON", ()=> {
-            let fineReturn = converterInstance.convert("18TXM10003000");
-            let coarseReturn = converterInstance.convert("18TXM13");
+            let fineReturn = converterInstance.mgrsToDecDeg("18TXM10003000");
+            let coarseReturn = converterInstance.mgrsToDecDeg("18TXM13");
             expect(fineReturn.geometry).toEqual(coarseReturn.geometry);
         });
     });
     describe("An invalid MGRS coordinate returns an error from Geotrans", () => {
         let invalidReturn = 'ERROR: Input Military Grid Reference System (MGRS): \nInvalid MGRS String\n';
         it("should return expected error from GeoTrans", ()=> {
-            expect(converterInstance.convert("18SJT9710003009")).toEqual(invalidReturn);
+            expect(converterInstance.mgrsToDecDeg("18SJT9710003009")).toEqual(invalidReturn);
         });
     });
     describe("An invalid MGRS coordinate returns an error from Geotrans", () => {
         let invalidReturn = 'ERROR: Invalid MGRS String';
         it("should return expected error from JS checker", ()=> {
-            expect(converterInstance.convert("4CFG")).toEqual(invalidReturn);
+            expect(converterInstance.mgrsToDecDeg("4CFG")).toEqual(invalidReturn);
         });
     });
+
+    describe("A valid decimal degree coordinate returns a valid point Geojson object and MGRS string", () => {
+        let validReturn = {
+            type: 'Feature',
+            geometry: {
+                type: 'Point',
+                coordinates: [-72.57553258519015, 42.367593344066776]
+            },
+            properties: {
+                name: '18TXM9963493438'
+            }
+        };
+
+        it("should return expected valid GeoJSON", ()=> {
+            expect(converterInstance.decDegToMgrs(42.367593344066776, -72.57553258519015)).toEqual(validReturn);
+        });
+    });
+    describe("An invalid decimal degree coordinate returns an error from Geotrans", () => {
+        let invalidReturn = 'ERROR: Invalid Coordinate';
+        it("should return expected error from JS", ()=> {
+            expect(converterInstance.decDegToMgrs(-181, -72)).toEqual(invalidReturn);
+        });
+    });
+    
 
 });

--- a/geotransMgrsConverter.spec.js
+++ b/geotransMgrsConverter.spec.js
@@ -9,7 +9,7 @@ describe("Geotrans MGRS Converter Tests", ()=>{
             type: 'Feature',
             geometry: {
                 type: 'Point',
-                coordinates: [-72.57553258519015, 42.367593344066776]
+                coordinates: [-72.57553, 42.36759]
             },
             properties: {
                 name: '18TXM9963493438'
@@ -45,10 +45,10 @@ describe("Geotrans MGRS Converter Tests", ()=>{
             type: 'Feature',
             geometry: {
                 type: 'Point',
-                coordinates: [-72.57553258519015, 42.367593344066776]
+                coordinates: [-72.57553, 42.36759]
             },
             properties: {
-                name: '18TXM9963493438'
+                name: '18TXM9963493437'
             }
         };
 

--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ function convert(req){
         }
         else if(req.query.from === "decdeg" && req.query.to === "mgrs"){
             let mgrs = new converter(req.query.datum);
-            let result = mgrs.decDegToMgrs(req.query.lat, req.query.lon, 1);
+            let result = mgrs.decDegToMgrs(req.query.lat, req.query.lon, 0);
             return result;
         }
     }

--- a/server.js
+++ b/server.js
@@ -4,11 +4,14 @@ const app = express();
 
 app.get('/', (req, res) => res.send(convert(req)));
 
-const port = process.env.PORT || '3000'
+const port = process.env.PORT || '3000';
 app.listen(port, () => console.log('GeoTrans MGRS Conversion service running at port ' + port));
 
 function convert(req){
     if(req.query){
+        if(!req.query.datum){
+            req.query.datum = 'WGE';
+        }
         if(req.query.from === "mgrs" && req.query.to === "decdeg"){
             let mgrs = new converter(req.query.datum);
             let result = mgrs.mgrsToDecDeg(req.query.q);

--- a/server.js
+++ b/server.js
@@ -9,8 +9,16 @@ app.listen(port, () => console.log('GeoTrans MGRS Conversion service running at 
 
 function convert(req){
     if(req.query){
-        let mgrs = new converter(req.query.datum);
-        let result = mgrs.convert(req.query.coord);
-        return result;
+        if(req.query.from === "mgrs" && req.query.to === "decdeg"){
+            let mgrs = new converter(req.query.datum);
+            let result = mgrs.mgrsToDecDeg(req.query.coord);
+            return result;
+        }
+        else if(req.query.from === "decdeg" && req.query.to === "mgrs"){
+            let mgrs = new converter(req.query.datum);
+            let result = mgrs.decDegToMgrs(req.query.lat, req.query.lon, 1);
+            return result;
+        }
     }
+    
 }

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ function convert(req){
     if(req.query){
         if(req.query.from === "mgrs" && req.query.to === "decdeg"){
             let mgrs = new converter(req.query.datum);
-            let result = mgrs.mgrsToDecDeg(req.query.coord);
+            let result = mgrs.mgrsToDecDeg(req.query.q);
             return result;
         }
         else if(req.query.from === "decdeg" && req.query.to === "mgrs"){


### PR DESCRIPTION
```javascript
// 20180517101342
// http://localhost:4000/v1/convert?from=decdeg&to=mgrs&lat=34.54586&lon=69.14558

{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [
      "69.14558",
      "34.54586"
    ]
  },
  "properties": {
    "name": "42SWD1335722692",
    "from": "decdeg",
    "to": "mgrs"
  }
}
```

This pull request introduces capability to convert from geodetic decimal degrees to MGRS coordinates. It also refactors the REST parameters to accept `from`, `to`, and `q` inputs rather than the mgrs-specific `coord` input. 

```javascript
// 20180517101351
// http://localhost:4000/v1/convert?from=mgrs&to=decdeg&q=42SWD1335722692

{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [
      "69.14558",
      "34.54586"
    ]
  },
  "properties": {
    "name": "42SWD1335722692",
    "from": "mgrs",
    "to": "decdeg"
  }
}
```

