### PR TITLE
Error handling

### DIFF
--- a/geotransMgrsConverter.js
+++ b/geotransMgrsConverter.js
@@ -1,15 +1,13 @@
 /** 
- * Geotrans MGRS Converter
+ * Geotrans Converter
  * @module geotransMgrsConverter
  * @author Gibran Parvez
- * Last updated: 11/14/2017
+ * Last updated: 05/08/2018
  */
-"use strict";
-//const setenv= require('setenv');
-const native = require('bindings')('native');
-//Required by mgrsToGeodetic.cpp for ellipsoid reference data
-//setenv.set('MSPCCS_DATA', 'geotrans3.7/data');
 
+"use strict";
+
+const native = require('bindings')('native');
 
 class MgrsConverter {
     constructor(datum){
@@ -49,6 +47,12 @@ class MgrsConverter {
         }
     }
 
+    /**
+     * Convert function. Primary usage of this module.
+     * @param {number} latitude - Alpha-numeric system for expressing geodetic latitude coordinate.
+     * @param {number} longitude - Alpha-numeric system for expressing geodetic longitude coordinate.
+     * @return {object} - geojson object featuring calculated MGRS string as property.
+     */
     decDegToMgrs(latitude, longitude){
         if((latitude > -90 && latitude < 90) && (longitude > -180 && longitude < 180) && this._datum){
             let conversionResult = require("./build/Release/native.node").callConvertToMgrs(this.constructor.degreesToRadians(latitude), this.constructor.degreesToRadians(longitude), 0, this._datum);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "preinstall": "./download_geotrans.sh && npm install node-gyp -g",
     "postinstall": "./node_modules/.bin/jasmine init && node-gyp configure build",
-    "test": "jasmine geotransMgrsConverter.spec.js"
+    "test": "jasmine geotransMgrsConverter.spec.js utils.spec.js"
   },
   "author": "Gibran Parvez",
   "license": "ISC",

--- a/server.js
+++ b/server.js
@@ -33,3 +33,7 @@ function convert(req, res){
         res.status(422).send({'errors': 'coordinate type not supported'});
     }
 }
+
+module.exports = { 
+    convert: convert
+};

--- a/server.js
+++ b/server.js
@@ -1,24 +1,35 @@
-const converter = require("./geotransMgrsConverter");
-const express = require('express');
-const app = express();
+/** 
+ * Geotrans Server
+ * @author Gibran Parvez
+ * Last updated: 05/08/2018
+ */
 
-app.get('/', (req, res) => res.send(convert(req)));
 
-const port = process.env.PORT || '3000'
-app.listen(port, () => console.log('GeoTrans MGRS Conversion service running at port ' + port));
+const converter = require("./geotransMgrsConverter"),
+    express = require('express'),
+    sanitize = require('./utils').sanitize,
+    app = express(),
+    port = process.env.PORT || '3000';
 
-function convert(req){
-    if(req.query){
-        if(req.query.from === "mgrs" && req.query.to === "decdeg"){
-            let mgrs = new converter(req.query.datum);
-            let result = mgrs.mgrsToDecDeg(req.query.q);
-            return result;
-        }
-        else if(req.query.from === "decdeg" && req.query.to === "mgrs"){
-            let mgrs = new converter(req.query.datum);
-            let result = mgrs.decDegToMgrs(req.query.lat, req.query.lon, 1);
-            return result;
-        }
+//Middleware for sanitize/error-checking
+app.use(sanitize);
+app.get('/', convert);
+app.listen(port, () => console.log('GeoTrans Conversion service running at port ' + port));
+
+/**
+     * Convert function. Determines which Geotrans conversion to perform based on given REST coordinates.
+     * @param {object} req - Express request
+     * @param {object} res - Express response
+*/
+function convert(req, res){
+    let converterInstance = new converter(req.query.datum);
+    if(req.query.from === "mgrs" && req.query.to === "decdeg"){
+        res.send(converterInstance.mgrsToDecDeg(req.query.q));
     }
-    
+    else if(req.query.from === "decdeg" && req.query.to === "mgrs"){
+        res.send(converterInstance.decDegToMgrs(req.query.lat, req.query.lon, 1));
+    }
+    else{
+        res.status(422).send({'errors': 'coordinate type not supported'});
+    }
 }

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,67 @@
+/** 
+ * Geotrans Server Utilities
+ * @author Gibran Parvez
+ * Last updated: 05/08/2018
+ */
+
+/**
+     * Sanitize function. Detects parameter errors or missing parameters.
+     * @param {object} req - Express request
+     * @param {object} res - Express response
+     * @param {function} next - Next function down the chain to be called.
+*/
+function sanitize (req, res, next) {
+    let invalid = [];
+    if(req.query.from && req.query.to && req.query.datum){
+        if(req.query.from === "mgrs" && req.query.to === "decdeg"){
+            if(!req.query.q){
+                invalid.push('q');
+            }
+            if(invalid.length > 0){
+                res.status(422).send(errorGenerator(invalid));
+            }
+            else{
+                next();
+            }
+        }
+        else{
+            if(!req.query.lat){
+                invalid.push('lat');
+            }
+            if(!req.query.lon){
+                invalid.push('lon');
+            }
+            if(invalid.length > 0){
+                res.status(422).send(errorGenerator(invalid));
+            }
+            else{
+                next();
+            }
+        }
+    }
+    else{
+        if(!req.query.from){
+            invalid.push('from');
+        }
+        if(!req.query.to){
+            invalid.push('to');
+        }
+        if(!req.query.datum){
+            invalid.push('datum');
+        }
+        res.status(422).send(errorGenerator(invalid));
+    }
+    
+}
+
+/**
+     * Return object to contain errors separated by comma.
+     * @param {array} params - List of parameter errors
+*/
+function errorGenerator(params){
+    return { 'errors': 'invalid or missing parameter: ' + params.join(', ')};
+}
+
+module.exports = {
+    sanitize: sanitize
+};

--- a/utils.spec.js
+++ b/utils.spec.js
@@ -1,0 +1,68 @@
+
+const jasmine = require('jasmine'),
+    sanitize = require('./utils').sanitize,
+    serverConvert = require('./server').convert;
+
+describe("Utilities tests", ()=> {
+    describe("Sanitizer tests", () => {
+        describe("Sanitizer tests", () => {
+            let errorReceived;
+            const res = {
+                status: (code) => {
+                    return {
+                        send: (msg) => {
+                            errorReceived = msg;
+                        }
+                    }
+                }
+            };
+            let req = { 'query': {}};
+            it('should fail if datum not given', () => {
+                req.query = {
+                        'from':'decdeg',
+                        'to':'mgrs'
+                    };
+                sanitize(req,res,null);
+                expect(errorReceived.errors).toBe('invalid or missing parameter: datum');
+            });
+            it('should fail if to not given', () => {
+                req.query = {
+                    'from':'decdeg',
+                    'datum':'WGE'
+                };
+                sanitize(req,res,null);
+                expect(errorReceived.errors).toBe('invalid or missing parameter: to');
+            });
+            it('should fail if q not given', () => {
+                req.query = {
+                        'from':'mgrs',
+                        'datum':'WGE',
+                        'to':'decdeg'
+                    };
+                sanitize(req,res,null);
+                expect(errorReceived.errors).toBe('invalid or missing parameter: q');
+            });
+            it('should fail if lat not given', () => {
+                req.query = {
+                    'from':'decdeg',
+                    'datum':'WGE',
+                    'to':'mgrs',
+                    'lon': -77
+                };
+                sanitize(req,res,null);
+                expect(errorReceived.errors).toBe('invalid or missing parameter: lat');
+            });
+            it('should fail if coordinate type not mgrs or decdeg', () => {
+                req.query = {
+                    'from':'mgrs',
+                    'datum':'WGE',
+                    'to':'utm',
+                    'lat':39,
+                    'lon':-79
+                };
+                serverConvert(req,res);
+                expect(errorReceived.errors).toBe('coordinate type not supported');
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR is an add-on to https://github.com/venicegeo/geotrans-mgrs-converter/pull/2 which allows proper _from_ and _to_ parameters for flexible coordinate conversion pipelines. Included code:

**Handles missing or invalid parameter:**

```javascript
// 20180508112853
// http://localhost:3000/?from=decdeg&to=mgrs&datum=WGE&lat=38&lon=

{
  "errors": "invalid or missing parameter: lon"
}
```

**Handles unsupported coordinate type:**
```javascript
// 20180508112956
// http://localhost:3000/?from=decdeg&to=654&datum=WGE&lat=38&lon=45

{
  "errors": "coordinate type not supported"
}
```