### PR TITLE
Handle invalid coordinates with appropriate HTTP error code

### DIFF
--- a/geotransMgrsConverter.js
+++ b/geotransMgrsConverter.js
@@ -43,7 +43,7 @@ class MgrsConverter {
             else{
                 console.log("Valid MGRS coordinate not supplied");
             }
-            return "ERROR: Invalid MGRS String";
+            return "invalid MGRS string";
         }
     }
 
@@ -66,7 +66,7 @@ class MgrsConverter {
             return this.constructor.generateJSON(conversionResult, latitude, longitude);
         }
         else{
-            return "ERROR: Invalid Coordinate";
+            return "invalid decimal degree coordinate";
         }
     }
     /**

--- a/geotransMgrsConverter.spec.js
+++ b/geotransMgrsConverter.spec.js
@@ -34,7 +34,7 @@ describe("Geotrans MGRS Converter Tests", ()=>{
         });
     });
     describe("An invalid MGRS coordinate returns an error from Geotrans", () => {
-        let invalidReturn = 'ERROR: Invalid MGRS String';
+        let invalidReturn = 'invalid MGRS string';
         it("should return expected error from JS checker", ()=> {
             expect(converterInstance.mgrsToDecDeg("4CFG")).toEqual(invalidReturn);
         });
@@ -57,7 +57,7 @@ describe("Geotrans MGRS Converter Tests", ()=>{
         });
     });
     describe("An invalid decimal degree coordinate returns an error from Geotrans", () => {
-        let invalidReturn = 'ERROR: Invalid Coordinate';
+        let invalidReturn = 'invalid decimal degree coordinate';
         it("should return expected error from JS", ()=> {
             expect(converterInstance.decDegToMgrs(-181, -72)).toEqual(invalidReturn);
         });

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@
 const converter = require("./geotransMgrsConverter"),
     express = require('express'),
     sanitize = require('./utils').sanitize,
+    validate = require('./utils').validate,
     app = express(),
     port = process.env.PORT || '3000';
 
@@ -30,10 +31,11 @@ function convert(req, res){
         let mgrs = new converter(req.query.datum);
         if(req.query.from === "mgrs" && req.query.to === "decdeg"){
             let result = mgrs.mgrsToDecDeg(req.query.q);
-            res.send(result);
+            validate(res, result);
         }
         else if(req.query.from === "decdeg" && req.query.to === "mgrs"){
             let result = mgrs.decDegToMgrs(req.query.lat, req.query.lon, 0);
+            validate(res, result);
             res.send(result);
         }
         else{

--- a/utils.js
+++ b/utils.js
@@ -53,7 +53,7 @@ function sanitize (req, res, next) {
 
 function validate(res, result){
     if(!result.geometry){
-        res.status(422).send(errorGenerator([], result));
+        res.status(400).send(errorGenerator([], result));
     }
     else{
         res.send(result);

--- a/utils.js
+++ b/utils.js
@@ -11,14 +11,14 @@
      * @param {function} next - Next function down the chain to be called.
 */
 function sanitize (req, res, next) {
-    let invalid = [];
+    let invalidParams = [];
     if(req.query.from && req.query.to){
         if(req.query.from === "mgrs" && req.query.to === "decdeg"){
             if(!req.query.q){
-                invalid.push('q');
+                invalidParams.push('q');
             }
-            if(invalid.length > 0){
-                res.status(422).send(errorGenerator(invalid));
+            if(invalidParams.length > 0){
+                res.status(422).send(errorGenerator(invalidParams));
             }
             else{
                 next();
@@ -26,13 +26,13 @@ function sanitize (req, res, next) {
         }
         else{
             if(!req.query.lat){
-                invalid.push('lat');
+                invalidParams.push('lat');
             }
             if(!req.query.lon){
-                invalid.push('lon');
+                invalidParams.push('lon');
             }
-            if(invalid.length > 0){
-                res.status(422).send(errorGenerator(invalid));
+            if(invalidParams.length > 0){
+                res.status(422).send(errorGenerator(invalidParams));
             }
             else{
                 next();
@@ -41,24 +41,40 @@ function sanitize (req, res, next) {
     }
     else{
         if(!req.query.from){
-            invalid.push('from');
+            invalidParams.push('from');
         }
         if(!req.query.to){
-            invalid.push('to');
+            invalidParams.push('to');
         }
-        res.status(422).send(errorGenerator(invalid));
+        res.status(422).send(errorGenerator(invalidParams));
     }
     
+}
+
+function validate(res, result){
+    if(!result.geometry){
+        res.status(422).send(errorGenerator([], result));
+    }
+    else{
+        res.send(result);
+    }
 }
 
 /**
      * Return object to contain errors separated by comma.
      * @param {array} params - List of parameter errors
 */
-function errorGenerator(params){
-    return { 'errors': 'invalid or missing parameter: ' + params.join(', ')};
+function errorGenerator(params, error){
+    if(params.length > 0){
+        return { 'errors': 'invalid or missing parameter: ' + params.join(', ')};
+    }
+    else{
+        return { 'errors': error };
+    }
+    
 }
 
 module.exports = {
-    sanitize: sanitize
+    sanitize: sanitize,
+    validate: validate
 };

--- a/utils.spec.js
+++ b/utils.spec.js
@@ -23,7 +23,7 @@ describe("Utilities tests", ()=> {
                         'to':'mgrs'
                     };
                 sanitize(req,res,null);
-                expect(errorReceived.errors).toBe('invalid or missing parameter: datum');
+                expect(errorReceived.errors).toBe('invalid or missing parameter: lat, lon');
             });
             it('should fail if to not given', () => {
                 req.query = {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32872347/40681250-9d73b2c0-6356-11e8-8153-c134a947245b.png)

This PR changes the server return when GeoTrans fails to convert invalid coordinates from a simple string to a JSON object featuring an `errors` key, consistent with the previously-added [middleware](https://github.com/venicegeo/geotrans-mgrs-converter/pull/4) for error-handling of malformed/missing query parameters.

## Failed decimal-degree to MGRS conversion:
**Before**:
```
// 20180529151442
// http://localhost:3000?from=decdeg&to=mgrs&lat=38.85450&lon=650
// Status: 200 OK
ERROR: Invalid Coordinate
```

**After**:
```
// 20180529151442
// http://localhost:3000/?from=decdeg&to=mgrs&lat=38.85450&lon=650
// Status: 400 BAD REQUEST 
{
  "errors": "invalid decimal degree coordinate"
}
```

## Failed MGRS to decimal-degree conversion:
**Before**:
```
// 20180529151442
// http://localhost:3000/?from=mgrs&to=decdeg&datum=WGE&q=4csa
// Status: 200 OK
ERROR: Invalid MGRS Coordinate
```

**After**:
```
// 20180529152854
// http://localhost:3000/?from=mgrs&to=decdeg&datum=WGE&q=4csa
// Status: 400 BAD REQUEST
{
  "errors": "invalid MGRS coordinate"
}
```
These changes are required for graceful error handling in Pelias-API as well.